### PR TITLE
AlwaysUAV: fix bug in FFA without sweep

### DIFF
--- a/GSC/AlwaysUAV/AlwaysUAV.gsc
+++ b/GSC/AlwaysUAV/AlwaysUAV.gsc
@@ -57,7 +57,7 @@ onPlayerConnect()
 onPlayerSpawn()
 {
 	self endon("disconnect");
-	self thread giveUavFFA();
+	if(getDvarInt("sweep_uav")) self thread giveUavFFA();
 	
 	for(;;)
 	{


### PR DESCRIPTION
level.uav_type will be undefined and cause an error in FFA without sweep, sweep logic shouldnt be called